### PR TITLE
LinuxProtocolHandlerRegistrar: don't register absolute path

### DIFF
--- a/BeatSaberModManager/Services/Implementations/ProtocolHandlerRegistrars/LinuxProtocolHandlerRegistrar.cs
+++ b/BeatSaberModManager/Services/Implementations/ProtocolHandlerRegistrars/LinuxProtocolHandlerRegistrar.cs
@@ -36,7 +36,7 @@ namespace BeatSaberModManager.Services.Implementations.ProtocolHandlerRegistrars
             using StreamReader streamReader = new(fileStream);
             while (streamReader.ReadLine() is { } line)
             {
-                if (line.StartsWith($"Exec={Environment.ProcessPath}", StringComparison.Ordinal))
+                if (line.StartsWith($"Exec={Program.Product}", StringComparison.Ordinal))
                     return true;
             }
 
@@ -73,7 +73,7 @@ Name={Program.Product}
 Comment=URL:{protocol} Protocol
 Type=Application
 Categories=Utility
-Exec={Environment.ProcessPath} --install %u
+Exec={Program.Product} --install %u
 Terminal=false
 NoDisplay=true
 MimeType=x-scheme-handler/{protocol}


### PR DESCRIPTION
The absolute path would point at the unwrapped binary. Some distros such as Nixpkgs must wrap their C# binaries in order to run them properly. This makes it so that BSMM is taken from the $PATH which is up to the user to popuate with the correct BeatSaberModManager.

Fixes https://github.com/affederaffe/BeatSaberModManager/issues/23